### PR TITLE
Bugfix/case more than 3 racers made false starts

### DIFF
--- a/pyjpboatrace/parsers/parse_html_raceresult.py
+++ b/pyjpboatrace/parsers/parse_html_raceresult.py
@@ -40,14 +40,20 @@ def parse_html_raceresult(html: str):
         dic = {}
         lst_trs = list(map(lambda tbody: tbody.select('tbody > tr'), tbodys))
 
+        def extract_result(td):
+            try:
+                return td.select_one(
+                    'div.numberSet1 > div.numberSet1_row'
+                ).text.split()
+            except AttributeError:
+                if "不成立" in td.text:
+                    return ["不成立"]
+                return [f"FailedToParse: {td.text}"]
+
         # trifecta
         tds = lst_trs[0][0].select('td')
         dic['trifecta'] = {
-            'result': ''.join(
-                tds[1].select_one(
-                    'div.numberSet1 > div.numberSet1_row'
-                ).text.split()
-            ),
+            'result': ''.join(extract_result(tds[1])),
             'payoff': str2num(
                 tds[2].select_one('span')
                       .text
@@ -61,11 +67,7 @@ def parse_html_raceresult(html: str):
         # trio
         tds = lst_trs[1][0].select('td')
         dic['trio'] = {
-            'result': ''.join(
-                tds[1].select_one(
-                    'div.numberSet1 > div.numberSet1_row'
-                ).text.split()
-            ),
+            'result': ''.join(extract_result(tds[1])),
             'payoff': str2num(
                 tds[2].select_one('span')
                       .text
@@ -79,11 +81,7 @@ def parse_html_raceresult(html: str):
         # exacta
         tds = lst_trs[2][0].select('td')
         dic['exacta'] = {
-            'result': ''.join(
-                tds[1].select_one(
-                    'div.numberSet1 > div.numberSet1_row'
-                ).text.split()
-            ),
+            'result': ''.join(extract_result(tds[1])),
             'payoff': str2num(
                 tds[2].select_one('span')
                       .text
@@ -97,11 +95,7 @@ def parse_html_raceresult(html: str):
         # quinella
         tds = lst_trs[3][0].select('td')
         dic['quinella'] = {
-            'result': ''.join(
-                tds[1].select_one(
-                    'div.numberSet1 > div.numberSet1_row'
-                ).text.split()
-            ),
+            'result': ''.join(extract_result(tds[1])),
             'payoff': str2num(
                 tds[2].select_one('span')
                       .text.replace('¥', '')
@@ -135,11 +129,7 @@ def parse_html_raceresult(html: str):
         # win
         tds = lst_trs[5][0].select('td')
         dic['win'] = {
-            'result': ''.join(
-                tds[1].select_one(
-                    'div.numberSet1 > div.numberSet1_row'
-                ).text.split()
-            ),
+            'result': ''.join(extract_result(tds[1])),
             'payoff': str2num(
                 tds[2].select_one('span')
                       .text
@@ -267,10 +257,10 @@ def parse_html_raceresult(html: str):
     )
 
     kimarite = inner_grid_units[1].select('div.table1')[1]\
-                                  .select_one('table > tbody > tr > td')
+        .select_one('table > tbody > tr > td')
 
     note_table = grid_units[3].select('div.table1')[-1]\
-                              .select('table > tbody > tr > td')
+        .select('table > tbody > tr > td')
 
     # parse
     dic = {

--- a/tests/test_pyjpboatrace.py
+++ b/tests/test_pyjpboatrace.py
@@ -534,7 +534,7 @@ class TestPyjpboatrace(unittest.TestCase):
     def test_get_race_result_missing_racer(self):
         # MISSING RACERS CASE #
 
-        for d, stadium, race in [
+        for d, std, race in [
             (date(2020, 11, 29), 10, 2),
             (date(2018, 1, 1), 21, 3),
             (date(2013, 9, 22), 1, 10),
@@ -547,12 +547,12 @@ class TestPyjpboatrace(unittest.TestCase):
             # expectation
             path = os.path.join(
                 self.expected_direc,
-                f"expected_raceresult.rno={race}&jcd={stadium:02d}&hd={dstr}.json"
+                f"expected_raceresult.rno={race}&jcd={std:02d}&hd={dstr}.json"
             )
             with open(path, 'r', encoding='utf-8-sig') as f:
                 expected = json.load(f)
             # actual
-            actual = self.pyjpboatrace.get_race_result(d, stadium, race)
+            actual = self.pyjpboatrace.get_race_result(d, std, race)
             # assertion
             assert actual == expected
 

--- a/tests/test_pyjpboatrace.py
+++ b/tests/test_pyjpboatrace.py
@@ -533,22 +533,28 @@ class TestPyjpboatrace(unittest.TestCase):
     )
     def test_get_race_result_missing_racer(self):
         # MISSING RACERS CASE #
-        # preparation
-        d = date(2020, 11, 29)
-        dstr = d.strftime('%Y%m%d')
-        stadium = 10
-        race = 2
-        # expectation
-        path = os.path.join(
-            self.expected_direc,
-            f"expected_raceresult.rno={race}&jcd={stadium:02d}&hd={dstr}.json"
-        )
-        with open(path, 'r', encoding='utf-8-sig') as f:
-            expected = json.load(f)
-        # actual
-        actual = self.pyjpboatrace.get_race_result(d, stadium, race)
-        # assertion
-        self.assertDictEqual(actual, expected)
+
+        for d, stadium, race in [
+            (date(2020, 11, 29), 10, 2),
+            (date(2018, 1, 1), 21, 3),
+            (date(2013, 9, 22), 1, 10),
+        ]:
+            # TODO use pytest.mark.parametrize
+            # ref. https://github.com/pytest-dev/pytest/issues/541
+
+            # preparation
+            dstr = d.strftime('%Y%m%d')
+            # expectation
+            path = os.path.join(
+                self.expected_direc,
+                f"expected_raceresult.rno={race}&jcd={stadium:02d}&hd={dstr}.json"
+            )
+            with open(path, 'r', encoding='utf-8-sig') as f:
+                expected = json.load(f)
+            # actual
+            actual = self.pyjpboatrace.get_race_result(d, stadium, race)
+            # assertion
+            assert actual == expected
 
     @pytest.mark.skipif(
         not os.path.exists(expected_direc),


### PR DESCRIPTION
# Abstract

Fix a bug occurred when getting race result in which more than 3 racers were disqualified.

# Check list

- [] it is possible to get the following race result: 
  1. 2018-1-1  race 3 in stadium 21;
  2. 2013-9-22 race 10 in stadium 1.