### PR TITLE
Fix packages in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -21,8 +21,7 @@ classifiers =
 
 
 [options]
-packages = 
-    pyjpboatrace
+packages = find:
 
 install_requires = 
     beautifulsoup4>=4.9.3
@@ -35,3 +34,7 @@ tests_require =
     pytest>=6.1.2
     pytest-cov>=2.10.1
     flake8>=3.8.4
+
+[options.packages.find]
+exclude =
+    tests*


### PR DESCRIPTION
# Abstract

The option for packages in setup.cfg does not work.
This pull request solve the problem.

# Changes
1. Change options.packages in setup.cfg
   - Old: packages = pyjpboatrace
   - New: packages = find:
2. Add options.packages.find.exclude to ignore test codes
   - exclude = tests*