### PR TITLE
Create pull_request_template.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,38 @@
+# Abstract
+A clear and concise description of what this pull-request is.
+
+# Objective
+Why do you create this pull-request?
+
+# What you did
+List what you did.
+
+- [o] what you did;
+- [] what you are doing.
+
+# Changes
+If applicable, add screenshots or codes to help explain this pull-request.
+
+- ex) screenshots for UI changes
+- ex) requests and responses for API changes
+
+# Impacts
+List clear and concise descriptions of impacts of this pull-request.
+
+- Impacts on users, e.g. What does this pull-request enable users to do?;
+- Impacts on developers;
+- Impacts on application;
+- ...
+
+# Operation check
+A clear and concise description of how to do/test and how to review.
+
+# Problems
+List problems.
+
+- what you are stucking on;
+- what you want to be reviewed;
+- ...
+
+# Additional context
+Add any other context about this pull-request here.

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -4,6 +4,15 @@ A clear and concise description of what this pull-request is.
 # Objective
 Why do you create this pull-request?
 
+# Type of change
+Select the typeof change.
+Please delete options that are not relevant.
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] This change requires a documentation update
+
 # What you did
 List what you did.
 


### PR DESCRIPTION
## Abstract
Create a template for pull-request.

## Objective
- To make clear what to write in pull-requests;
- To reduce the cost of reviews for pull-requests.

## What you did
- [o] create .github/PULL_REQUERST_TEMPLATE/pull_request_template.md

## Changes
See .github/PULL_REQUERST_TEMPLATE/pull_request_template.md

## Impacts
- Impact on developers: developers can user a pull-request to create pull-request;
- Impact on developers: reviewers can check information they need when reviewing.

## Operation check
Read .github/PULL_REQUERST_TEMPLATE/pull_request_template.md