### PR TITLE
chore: update Python version matrix in workflow files

### DIFF
--- a/.github/workflows/code-style-check-workflow-call.yaml
+++ b/.github/workflows/code-style-check-workflow-call.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9, "3.10", "3.11", "3.12"]
+        python-version: [3.9, "3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/pytest-workflow-call.yaml
+++ b/.github/workflows/pytest-workflow-call.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9, "3.10", "3.11", "3.12"]
+        python-version: [3.9, "3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/static-type-check-workflow-call.yaml
+++ b/.github/workflows/static-type-check-workflow-call.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9, "3.10", "3.11", "3.12"]
+        python-version: [3.9, "3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v3
         with:

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ one of the following browers is required at least:
 
 ### Dependencies
 
-- python >= 3.8
+- python >= 3.9
 - requests>=2.28.1
 - beautifulsoup4>=4.11.1
 - selenium>=4.6
@@ -1299,7 +1299,7 @@ The map between integers and stadiums is given by `STADIUMS_MAP` in `pyjpboatrac
 
 ### Requirement
 
-- Python >= 3.8
+- Python >= 3.9
 - Chrome
 - Firefox
 - bash

--- a/README.md.j2
+++ b/README.md.j2
@@ -25,7 +25,7 @@ one of the following browers is required at least:
 
 ### Dependencies
 
-- python >= 3.8
+- python >= 3.9
 - requests>=2.28.1
 - beautifulsoup4>=4.11.1
 - selenium>=4.6
@@ -497,7 +497,7 @@ The map between integers and stadiums is given by `STADIUMS_MAP` in `pyjpboatrac
 
 ### Requirement
 
-- Python >= 3.8
+- Python >= 3.9
 - Chrome
 - Firefox
 - bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,13 +17,12 @@ keywords = ["kyotei", "boatrace", "data analysis"]
 classifiers = [
     "Development Status :: 2 - Pre-Alpha",
     "License :: OSI Approved :: MIT License",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 
 dependencies = [
     "beautifulsoup4>=4.11.1",


### PR DESCRIPTION
## Abstract

Deprecate Python 3.8, because Python 3.8 reached its end-of-life on October 7, 2024.

[PEP 569 – Python 3.8 Release Schedule](https://peps.python.org/pep-0569/)

## Type of change

Update the version of python

## What you did

- [x] drop python 3.8 from github actions
- [x] update the requirements in README
- [x] update  pyproject.toml

## Impacts

- Impacts on users
  - `pyjpboatrace` does not work with Python 3.8
- Impacts on developers;
  - `pyjpboatrace` does not work with Python 3.8