### PR TITLE
Update-github-actions

### DIFF
--- a/.github/workflows/code-style-check-workflow-call.yaml
+++ b/.github/workflows/code-style-check-workflow-call.yaml
@@ -20,6 +20,8 @@ jobs:
     strategy:
       matrix:
         python-version: [3.9, "3.10", "3.11", "3.12"]
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/on_push_tags.yaml
+++ b/.github/workflows/on_push_tags.yaml
@@ -14,17 +14,15 @@ jobs:
     needs: [validate-version]
     if: ${{ failure() }}
     runs-on: ubuntu-latest
-    env:
-      PRIVATE_REPO_USER: "hmasdev"
-    strategy:
-      matrix:
-        python-version: [3.9]
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.11"
       - name: Update Tags
         run: |
           # Get the latest tag
@@ -70,13 +68,11 @@ jobs:
             --assignee hmasdev \
             --reviewer hmasdev \
             --label "bot"
-
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Create a Draft Release
         shell: bash
         run: |
           gh release create $tag --title "Release $tag" --notes "Release $tag" --draft
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/on_release.yaml
+++ b/.github/workflows/on_release.yaml
@@ -24,6 +24,8 @@ jobs:
   build:
     needs: [test, static-type-check, code-style-check, validate-version]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python 3.11
@@ -61,6 +63,8 @@ jobs:
   publish-to-github:
     needs: [build]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Download the distribution files
         uses: actions/download-artifact@v4

--- a/.github/workflows/on_release.yaml
+++ b/.github/workflows/on_release.yaml
@@ -21,53 +21,54 @@ jobs:
     uses: ./.github/workflows/validate-version-workflow-call.yaml
     with:
       git-ref: ${{ github.ref }}
-  deploy:
+  build:
     needs: [test, static-type-check, code-style-check, validate-version]
     runs-on: ubuntu-latest
-    env:
-      PRIVATE_REPO_USER: "hmasdev"
-    strategy:
-      matrix:
-        python-version: [3.9]
     steps:
-      - uses: actions/checkout@v1
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
+      - uses: actions/checkout@v4
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install requirements
+          python-version: "3.11"
+      - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip wheel setuptools twine
-          python -m pip install uv
-          uv sync --dev
-      - name: Build
+          python -m pip install --upgrade pip
+          pip install -U uv
+      - name: Build a binary wheel and a source tarball
         run: |
           uv build
-          echo "whl_name=$(ls dist/*whl | cut -d / -f 2)" >> $GITHUB_ENV
-          echo "tar_name=$(ls dist/*tar.gz | cut -d / -f 2)" >> $GITHUB_ENV
-      - name: Upload Wheel to GitHub
-        uses: actions/upload-release-asset@v1
+      - name: Store the distribution files as artifacts
+        uses: actions/upload-artifact@v4
         with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ./dist/*.whl
-          asset_name: ${{ env.whl_name }}
-          asset_content_type: application/octet-stream
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Upload tar.gz to GitHub
-        uses: actions/upload-release-asset@v1
+          name: python-package-distributions
+          path: dist/
+  publish-to-pypi:
+    needs: [build]
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/pyjpboatrace
+    permissions:
+      id-token: write
+    steps:
+      - name: Download the distribution files
+        uses: actions/download-artifact@v4
         with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ./dist/*.tar.gz
-          asset_name: ${{ env.tar_name }}
-          asset_content_type: application/octet-stream
+          name: python-package-distributions
+          path: dist/
+      - name: Publish distribution to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+  publish-to-github:
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download the distribution files
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+      - name: Upload distribution files to GitHub
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Upload to PyPI
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          uv run python -m twine upload --repository pypi dist/*
-        env:
-          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-          TWINE_REPOSITORY_URL: https://upload.pypi.org/legacy/
-          TWINE_SKIP_EXISTING: true
+          gh release upload "$GITHUB_REF_NAME" dist/* --repo "$GITHUB_REPOSITORY" --clobber

--- a/.github/workflows/pytest-workflow-call.yaml
+++ b/.github/workflows/pytest-workflow-call.yaml
@@ -20,6 +20,8 @@ jobs:
     strategy:
       matrix:
         python-version: [3.9, "3.10", "3.11", "3.12"]
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/static-type-check-workflow-call.yaml
+++ b/.github/workflows/static-type-check-workflow-call.yaml
@@ -20,6 +20,8 @@ jobs:
     strategy:
       matrix:
         python-version: [3.9, "3.10", "3.11", "3.12"]
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/update-readme.yaml
+++ b/.github/workflows/update-readme.yaml
@@ -11,10 +11,12 @@ env:
 jobs:
   update-readme:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
       - name: Setup Python 3.11
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.11"
       - name: Install dependencies
@@ -61,5 +63,5 @@ jobs:
             --assignee hmasdev \
             --label "bot"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_RUN_ID: ${{ github.run_id }}

--- a/.github/workflows/validate-version-workflow-call.yaml
+++ b/.github/workflows/validate-version-workflow-call.yaml
@@ -20,11 +20,11 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.git-ref }}
       - name: Set up Python 3.11
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v5
         with:
           python-version: "3.11"
       - name: Install requirements

--- a/.github/workflows/validate-version-workflow-call.yaml
+++ b/.github/workflows/validate-version-workflow-call.yaml
@@ -17,19 +17,16 @@ on:
 jobs:
   validate_version:
     runs-on: ubuntu-latest
-    env:
-      PRIVATE_REPO_USER: "hmasdev"
-    strategy:
-      matrix:
-        python-version: [3.9]
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v3
         with:
           ref: ${{ inputs.git-ref }}
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python 3.11
         uses: actions/setup-python@v1
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.11"
       - name: Install requirements
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
## Abstract

This pull request refactors several GitHub Actions workflows to enhance clarity, security, and maintainability. It also fixes a critical bug in the betting dictionary initialization logic in the core Python module.

## Objective

To improve GitHub Actions workflow structure, align permissions appropriately, switch to latest `actions/setup-python`, and fix incorrect dictionary fallback behavior in `pyjpboatrace.py`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## What you did

- [x] Added `permissions:` explicitly to all workflows for least privilege;
- [x] Migrated `actions/setup-python` to `v5`;
- [x] Switched from `upload-release-asset` to `gh release upload` for modern asset handling;
- [x] Replaced inlined build and upload steps with artifacts and dedicated build/publish jobs;
- [x] Fixed betting dict initialization bug where all dicts were wrongly referencing `trifecta_betting_dict`.

## Changes

**Workflow changes:**
- `permissions:` added to all jobs (e.g., `contents: read`, `id-token: write`, `pull-requests: write`);
- Removed obsolete matrix usage in jobs where not needed;
- `upload-release-asset@v1` replaced by `gh release upload` CLI usage;
- Adopted `actions/upload-artifact@v4` and `actions/download-artifact@v4` for clearer dist file handling.

**Python changes:**
Before:
```python
trio_betting_dict = trio_betting_dict or {}
