### PR TITLE
Add write permission for contents in update-readme workflow

### DIFF
--- a/.github/workflows/update-readme.yaml
+++ b/.github/workflows/update-readme.yaml
@@ -12,6 +12,7 @@ jobs:
   update-readme:
     runs-on: ubuntu-latest
     permissions:
+      contents: write
       pull-requests: write
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Grant write permission for contents in the update-readme workflow to enable necessary updates.