### PR TITLE
feat: Add BasePyJPBoatraceException as common base for all library exceptions (Issue #109)

### DIFF
--- a/pyjpboatrace/exceptions.py
+++ b/pyjpboatrace/exceptions.py
@@ -1,22 +1,27 @@
-class NoDataException(Exception):
+class BasePyJPBoatraceException(Exception):
+    """Base class for all pyjpboatrace-specific exceptions."""
     pass
 
 
-class RaceCancelledException(Exception):
+class NoDataException(BasePyJPBoatraceException):
+    pass
+
+
+class RaceCancelledException(BasePyJPBoatraceException):
     def __init__(self, msg=None):
         super().__init__(msg)
 
 
-class UnableActionException(Exception):
+class UnableActionException(BasePyJPBoatraceException):
     def __init__(self, msg=None):
         super().__init__(msg)
 
 
-class LoginFailException(Exception):
+class LoginFailException(BasePyJPBoatraceException):
     pass
 
 
-class InsufficientDepositException(Exception):
+class InsufficientDepositException(BasePyJPBoatraceException):
     pass
 
 
@@ -24,21 +29,37 @@ class ZeroDepositException(InsufficientDepositException):
     pass
 
 
-class VoteNotInTimeException(Exception):
+class VoteNotInTimeException(BasePyJPBoatraceException):
     pass
 
 
-class InactiveStadium(Exception):
+class InactiveStadium(BasePyJPBoatraceException):
     pass
 
 
-class InactiveRace(Exception):
+class InactiveRace(BasePyJPBoatraceException):
     pass
 
 
-class UserInformationNotGivenException(Exception):
+class UserInformationNotGivenException(BasePyJPBoatraceException):
     pass
 
 
-class UnexpectedException(Exception):
+class UnexpectedException(BasePyJPBoatraceException):
     pass
+
+
+__all__ = [
+    "BasePyJPBoatraceException",
+    "NoDataException",
+    "RaceCancelledException",
+    "UnableActionException",
+    "LoginFailException",
+    "InsufficientDepositException",
+    "ZeroDepositException",
+    "VoteNotInTimeException",
+    "InactiveStadium",
+    "InactiveRace",
+    "UserInformationNotGivenException",
+    "UnexpectedException",
+]


### PR DESCRIPTION
# Pull Request Template

Thank you for your contribution to the project!

Please fill out the following template to help us review your pull-request.

## Abstract

Add `BasePyJPBoatraceException` as a common base exception class for all pyjpboatrace-specific exceptions, enabling users to catch all library errors with a single except statement.

## Objective

Resolve Issue #109 by implementing a common base exception pattern that:
- Simplifies error handling for library users
- Follows Python library best practices (similar to `requests.RequestException`)
- Maintains full backward compatibility
- Improves future extensibility

## Type of change

Select the typeof change.
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## What you did

List what you did.

- [x] Added `BasePyJPBoatraceException` base class that inherits from `Exception`
- [x] Updated all 11 existing exception classes to inherit from `BasePyJPBoatraceException` instead of `Exception`
- [x] Preserved existing inheritance relationships (e.g., `ZeroDepositException` still inherits from `InsufficientDepositException`)
- [x] Added `__all__` export list for better API clarity
- [x] Verified backward compatibility with comprehensive tests

## Changes

### Code Changes
```python
# Before: All exceptions inherited directly from Exception
class NoDataException(Exception):
    pass

# After: All exceptions inherit from BasePyJPBoatraceException
class BasePyJPBoatraceException(Exception):
    """Base class for all pyjpboatrace-specific exceptions."""
    pass

class NoDataException(BasePyJPBoatraceException):
    pass
```

### New Usage Pattern
```python
# Users can now catch all library-specific exceptions
try:
    # pyjpboatrace operations
    pass
except BasePyJPBoatraceException as e:
    # Handle any library-specific error
    pass
```

## Impacts

List clear and concise descriptions of impacts of this pull-request.

- **Impacts on users**: Users can now catch all library-specific errors with a single `except BasePyJPBoatraceException:` statement, simplifying error handling
- **Impacts on developers**: Future exception additions will automatically benefit from the common base class pattern
- **Impacts on application**: Zero breaking changes - all existing code continues to work unchanged
- **API improvement**: Better structured exception hierarchy following Python best practices

## Operation check

### Test Results
- ✅ All unit tests pass (99/99 tests)
- ✅ Linting passes with no issues (`uv run ruff check`)
- ✅ Type checking passes with no issues (`uv run mypy`)
- ✅ Backward compatibility verified - existing exception handling code works unchanged
- ✅ New base exception can catch all library-specific exceptions as intended

### How to test
```bash
# Run tests
uv run pytest -m "not integrate"

# Verify linting
uv run ruff check pyjpboatrace tests

# Verify type checking
uv run mypy pyjpboatrace tests
```

## Problems

List problems.

- None identified - implementation is complete and all tests pass

## Additional context

- Implements the exact solution proposed in Issue #109
- Follows the minimal patch approach suggested in the issue
- Maintains 100% backward compatibility
- Ready for merge after review

🤖 Generated with [Claude Code](https://claude.ai/code)