### PR TITLE
Fix parse error in get_stadiums during pre-sales (前日投票) (Issue #106)

### DIFF
--- a/pyjpboatrace/scraper/_parser/parse_html_index.py
+++ b/pyjpboatrace/scraper/_parser/parse_html_index.py
@@ -44,6 +44,9 @@ def parse_html_index(html: str):
             next_race = int(tds.pop().get_text().replace('R', ''))
             next_vote_limit = trs[1].select_one('td').get_text()
             tds.pop()  # ignore vote button
+        elif "前日" in status.text:
+            # case : pre-sales is ongoing or completed
+            tds.pop()  # ignore vote button
 
         grade = tds.pop()['class']
         timeframe = tds.pop().get("class", "")

--- a/tests/data/expected_today_index_with_day_before_sales.json
+++ b/tests/data/expected_today_index_with_day_before_sales.json
@@ -1,0 +1,16 @@
+{
+    "date": "DUMMY",
+    "会場": {
+        "status": "前日発売中",
+        "grade": [
+            "ippan"
+        ],
+        "timeframe": "nighter",
+        "title": "タイトル",
+        "period": [
+            "2020-11-30",
+            "2020-12-04"
+        ],
+        "day": "１日目"
+    }
+}

--- a/tests/mock_html/today_index_with_day_before_sales.html
+++ b/tests/mock_html/today_index_with_day_before_sales.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="ja">
+
+<head></head>
+
+<body>
+    <main class="l-main">
+        <div class="l-mainWrap is-type3">
+            <div class="l-mainInner">
+                <div class="contentsFrame1">
+                    <div class="contentsFrame1_inner">
+                        <div class="btnGroup3">
+                            <p class="btnGroup3_refreshBtn"><a href="/owpc/pc/race/index?hd=20201130"
+                                    class="btn is-type1_2">更新<i class="is-refresh1"></i></a></p>
+                        </div>
+                        <div class="table1">
+                            <table>
+                                <tbody>
+                                    <tr>
+                                        <td class="is-arrow1 is-fBold is-fs15" rowspan="2"><a><img alt="会場">"></a></td>
+                                        <td rowspan="2" colspan="2">前日<br>発売中</td>
+                                        <td rowspan="2"><a id="TENTP090A0" class="btn is-type4_2">投票</a></td>
+                                        <td rowspan="2" class="is-ippan "></td>
+                                        <td rowspan="2" class="is-nighter"></td>
+                                        <td class="is-alignL is-fBold is-p10-7" rowspan="2"><a
+                                                href="/owpc/pc/race/raceindex?jcd=01&hd=20201201">タイトル</a></td>
+                                        <td rowspan="2">11/30-12/4<br>１日目</td>
+                                        <td class="is-alignL is-p10-7" rowspan="2"></td>
+                                        <td rowspan="2"><a></a></td>
+                                        <td rowspan="2"><a></a></td>
+                                    </tr>
+                                    <tr class="is-fBold is-fs15">
+                                    </tr>
+                                </tbody>
+                            </table><!-- /.table -->
+                        </div>
+                    </div><!-- /.contentsFrame1_inner -->
+                </div><!-- /.contentsFrame1 -->
+            </div><!-- /.l-mainInner -->
+        </div><!-- /.l-mainWrap -->
+    </main>
+</body>
+
+</html>

--- a/tests/scraper/test_stadiums_scraper.py
+++ b/tests/scraper/test_stadiums_scraper.py
@@ -57,6 +57,10 @@ def test_get(d: date):
             "today_index.html",
             "expected_today_index.json"
         ),
+        (
+            "today_index_with_day_before_sales.html",
+            "expected_today_index_with_day_before_sales.json"
+        ),
     ]
 )
 def test_get_for_today(mock_html_file, expected_file):

--- a/tests/test_pyjpboatrace.py
+++ b/tests/test_pyjpboatrace.py
@@ -57,15 +57,32 @@ def test_get_stadiums(d: date, boatrace_tools: PyJPBoatrace):
 
 
 @mock.patch('selenium.webdriver.Chrome')
-def test_get_stadiums_today(mock_chrome):
+@pytest.mark.parametrize(
+    "mock_html,expected_json",
+    [
+        (
+            "today_index.html",
+            "expected_today_index.json",
+        ),
+        (
+            "today_index_with_day_before_sales.html",
+            "expected_today_index_with_day_before_sales.json",
+        ),
+    ]
+)
+def test_get_stadiums_today(
+    mock_chrome,
+    mock_html: str,
+    expected_json: str,
+):
     # TODAY (=2020/11/30) CASE #
     # preparation
     d = date(2020, 11, 30)
     # set mock
-    mock_chrome.page_source = get_mock_html("today_index.html")
+    mock_chrome.page_source = get_mock_html(mock_html)
 
     # expectation
-    expected = get_expected_json('expected_today_index.json')
+    expected = get_expected_json(expected_json)
     expected.update(date=d.strftime("%Y-%m-%d"))
 
     # actual


### PR DESCRIPTION
## Abstract

Fix parse error in `get_stadiums()` method when pre-sales (前日投票) is ongoing for SG, Premium G1, G2 Ladies All Star, G2 National Boat Race Koshien, and Fan Appreciation 3Days races.

## Objective

Resolve the `KeyError: 'class'` error that occurs when calling `get_stadiums()` during pre-sales periods. This error prevents users from retrieving stadium information during important race periods.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## What you did

- [x] Added pre-sales detection logic in HTML parser to handle extra `<td>` element
- [x] Created test case with mock HTML for pre-sales scenario
- [x] Added expected JSON output for pre-sales test case
- [x] Updated existing integration tests to cover pre-sales functionality

## Changes

### Core Fix
- Modified `pyjpboatrace/scraper/_parser/parse_html_index.py` to detect "前日" in status text and handle the extra vote button `<td>` element that appears during pre-sales

### Test Coverage
- Added `tests/mock_html/today_index_with_day_before_sales.html` - mock HTML representing pre-sales state
- Added `tests/data/expected_today_index_with_day_before_sales.json` - expected parser output
- Updated `tests/scraper/test_stadiums_scraper.py` and `tests/test_pyjpboatrace.py` to include pre-sales test cases

## Impacts

### Impacts on users
- Users can now successfully call `get_stadiums()` during pre-sales periods without encountering parse errors
- Enables data collection during important SG and Premium G1 race periods

### Impacts on developers
- Provides robust handling of HTML structure variations during different race phases
- Adds comprehensive test coverage for edge cases

### Impacts on application
- Improves reliability of stadium data scraping across all race periods
- Maintains backward compatibility with existing functionality

## Operation check

### Testing
```bash
# Run all tests including the new pre-sales test case
uv run pytest tests/scraper/test_stadiums_scraper.py::test_get_for_today -v
uv run pytest tests/test_pyjpboatrace.py::test_get_stadiums_today -v

# Run full test suite
uv run pytest -m "not integrate and not spending_money"
```

### Manual Verification
The fix handles the HTML structure described in issue #106 where pre-sales creates an extra `<td>` element:
```html
<td rowspan="2"><a id="TENTP090A6" href="/owpc/VoteConfirm.xhtml?authAfterTrans=stay&voteTagId=TENTP090A6" class="btn is-type4_2">投票</a></td>
```

## Problems

None identified. The fix follows the suggestion from the issue reporter and maintainer comments, and comprehensive tests verify the solution.

## Additional context

This fix addresses Issue #106 reported by @osewa-org. The solution implements the suggested workaround that detects pre-sales status and removes the extra vote button element before parsing grade information.

Pre-sales apply to specific high-grade races as documented in the official boatrace website: https://www.boatrace.jp/owpc/pc/extra/tb/support/information/n_time.html

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>