### PR TITLE
fix: follow site drift (VoteBridgeNew .jsp→.xhtml and btnSubmit CSS scope) (#115)

### DIFF
--- a/pyjpboatrace/const.py
+++ b/pyjpboatrace/const.py
@@ -12,7 +12,7 @@ BOATRACEJP_BASE_URL = f"{BOATRACEJP_MAIN_URL}owpc/pc/race"
 
 IBMBRACEORJP = ''.join([
     f'{BOATRACEJP_MAIN_URL}',
-    'owpc/VoteBridgeNew.jsp?',
+    'owpc/VoteBridgeNew.xhtml?',
     'param=H0JS00000stContens'
     '&kbn=1'
     '&voteActionUrl=/owpc/pc/site/index.html'

--- a/pyjpboatrace/operator/better.py
+++ b/pyjpboatrace/operator/better.py
@@ -159,8 +159,11 @@ class BettingOperator(BaseOperator, DriverCheckMixin):
 
                 amount = amount + amt
 
-        # complete input
-        self._driver.find_element(By.CLASS_NAME, 'btnSubmit').click()
+        # complete input (target the "投票入力完了" button inside .inputCompletion;
+        # plain CLASS_NAME 'btnSubmit' also matches hidden password-change forms)
+        self._driver.find_element(
+            By.CSS_SELECTOR, '.inputCompletion .btnSubmit a'
+        ).click()
 
         # insufficient depost
         if amount > limit:
@@ -170,7 +173,10 @@ class BettingOperator(BaseOperator, DriverCheckMixin):
                 f'but your current deposit is {limit}.'
             )
 
-        # confirmation
+        # confirmation page — wait for the betconf DOM to appear
+        WebDriverWait(self._driver, timeout).until(
+            EC.presence_of_element_located((By.ID, 'pass'))
+        )
         self._driver.find_element(By.ID, 'amount').send_keys(str(amount))
         self._driver.find_element(By.ID, 'pass').send_keys(self._user.vote_pass)  # noqa
         self._driver.find_element(By.ID, 'submitBet').click()


### PR DESCRIPTION
## Summary

Fixes two independent drifts that break the entire voting flow against
the current live site. Details and reproduction are in #115.

- **Drift 1**: `VoteBridgeNew.jsp` → `VoteBridgeNew.xhtml`
  (`get_bet_limit` / login redirected to the SP error page).
  `pyjpboatrace/const.py`, 1 line.
- **Drift 2**: `By.CLASS_NAME, 'btnSubmit'` is ambiguous on the current
  DOM (matches hidden password-change forms first). Scoped to
  `By.CSS_SELECTOR, '.inputCompletion .btnSubmit a'` and added a
  `WebDriverWait` for the confirmation page's `id=pass`.
  `pyjpboatrace/operator/better.py`, 9/-3.

Both commits are independently reviewable.

## Test plan

- [x] `get_bet_limit()` returns the correct numeric balance on the live
      site (verified twice: before and after deposit).
- [x] `bet(stadium=14, race=11, trifecta_betting_dict={'1-2-3': 100})`
      succeeds end-to-end against the live site, balance decreases by
      100 yen, and the bet appears in the official vote history.
- [ ] Unit tests — not added here because the existing `better.py`
      tests appear to be Selenium integration tests. Happy to add
      mock-based unit tests for the new CSS selector in a follow-up
      commit if you prefer a specific style.

## Notes

- `deposit()` / `withdraw()` paths are not covered in this PR because I
  rely on manual web-UI deposits in my own operation. They may still
  work unchanged once Drift 1 is fixed, but I have not verified them.
- No behavior change when the login URL / DOM revert: the CSS selector
  `.inputCompletion .btnSubmit a` is strictly more specific than
  `.btnSubmit` and should still match the intended button, while the
  `WebDriverWait` only adds a few milliseconds on the happy path.

Closes #115